### PR TITLE
fix netloc to hostname to remove port number

### DIFF
--- a/pypac/resolver.py
+++ b/pypac/resolver.py
@@ -48,11 +48,11 @@ class ProxyResolver(object):
             Can be empty, which means to abort the request.
         :rtype: list[str]
         """
-        value_from_js_func = self.pac.find_proxy_for_url(url, urlparse(url).netloc)
+        value_from_js_func = self.pac.find_proxy_for_url(url, urlparse(url).hostname)
         if value_from_js_func in self._cache:
             return self._cache[value_from_js_func]
 
-        config_values = parse_pac_value(self.pac.find_proxy_for_url(url, urlparse(url).netloc), self.socks_scheme)
+        config_values = parse_pac_value(self.pac.find_proxy_for_url(url, urlparse(url).hostname), self.socks_scheme)
         if self._proxy_auth:
             config_values = [add_proxy_auth(value, self._proxy_auth) for value in config_values]
 


### PR DESCRIPTION
the find_proxy_for_url was called with the netloc that includes the port number. 
replace it by the hostname to avoid exceptio `TypeError: inet_aton() argument 1 must be str, not None` in is_ipv4_address