### PR TITLE
Defer js2py import until it's needed, to conserve memory.

### DIFF
--- a/pypac/parser.py
+++ b/pypac/parser.py
@@ -1,10 +1,8 @@
 """
 Functions and classes for parsing and executing PAC files.
 """
-import js2py
 import warnings
 from contextlib import contextmanager
-from js2py.base import PyJsException
 
 import sys
 
@@ -49,6 +47,9 @@ class PACFile(object):
         """
         self._recursion_limit = recursion_limit
 
+        # Defer importing of js2py, as it greatly increases memory use (~120MB). See #20.
+        import js2py
+
         if 'pyimport' in pac_js:
             raise PyimportError()
         # Disallow parsing of the unsafe 'pyimport' statement in Js2Py.
@@ -62,7 +63,7 @@ class PACFile(object):
 
             self._context = context
             self._func = context.FindProxyForURL
-        except PyJsException:  # as e:
+        except js2py.base.PyJsException:  # as e:
             raise MalformedPacError()  # from e
         except RuntimeError:
             # RecursionError in PY >= 3.5.

--- a/pypac/parser_functions.py
+++ b/pypac/parser_functions.py
@@ -10,7 +10,6 @@ import socket
 from calendar import monthrange
 from datetime import datetime, time, date
 from fnmatch import fnmatch
-from js2py.base import PyJs
 from requests.utils import is_ipv4_address
 
 import struct
@@ -23,6 +22,7 @@ def _to_py(value):
     :param str|PyJs value: Value to convert.
     :rtype: str
     """
+    from js2py.base import PyJs  # Defer to conserve memory when PAC not loaded.
     if isinstance(value, PyJs):
         return value.value
     return value


### PR DESCRIPTION
As noted in #20, importing js2py will immediately consume upwards of 120MB of memory. This change defers such an import until necessary, i.e. when we have a PAC file to parse.

This only helps the scenario where PyPAC is imported but doesn't end up finding/using any PAC.