### PR TITLE
Switch JavaScript engine from js2py to dukpy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,20 +1,15 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
-"js2py" = "*"
 requests = "*"
 tld = "*"
 "e1839a8" = {path = ".", editable = true}
-
+dukpy = "*"
 
 [dev-packages]
-
 pytest = "*"
 mock = "*"
 pytest-cov = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5b5ca2d78d8de026685cc0657910ded5a42ea118f486772e117c08670152ad5c"
+            "sha256": "69dd87dde70f0059320a864a909b37ad2afe07572e808343b5c32131e0538c94"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -28,6 +28,35 @@
             ],
             "version": "==3.0.4"
         },
+        "dukpy": {
+            "hashes": [
+                "sha256:0f85faca6d32044ac64347965c4d3e8c19c92df03d40ca9bf93ae38dfefba8d4",
+                "sha256:1ca72a30adae4e5dccb870586e47efb9dc62948bba1a2bc4de901daa69e85ced",
+                "sha256:259e73b6d2ee2e588c682411620aa73c2b3666165a9993d2197bf10571da2f44",
+                "sha256:25c44076371dd2c7c2677d9febd36d526112f15871ccaa8489465b849a091913",
+                "sha256:2e6868a56a167a53f9cd54faf4a4e788c800413eb87912d13511adef8d0ff194",
+                "sha256:35e51b7a21b93d7521f68825af3693f6cc89456154df7fe201af5268bc84018e",
+                "sha256:3ae50a560248f8aa6c2ea344bbf084931500c35c11ebf1d2af209657f27a8f4a",
+                "sha256:42867ca64351c945d41ccf0decd268b61e0bc626a1456efa08f1ee3ee1f1aacf",
+                "sha256:4666452afd7055bfa1c722fb0083d59489ed97f50ea853fdf50d7774a16c434d",
+                "sha256:5331e75bb3466d81363d863d75663e88805713ff921692a6848cd58bb61d1939",
+                "sha256:53f2262a160997e845c524f028d5aa8287c67dd9c84aaefbb1c39087b69d9850",
+                "sha256:6193f6dd51f7938d11e71a2a17850805e57c3d8e4ce5a3126201f27cf69e5e23",
+                "sha256:633fb249e4c377df6f8013bbf676e94004f854a8785b944eca11ce80c4b65f77",
+                "sha256:68de6cdfd36e85551d4057fcc612224dab76f1a8878fde7688d0a16e681fa963",
+                "sha256:69ab6473da569925a960c420f8b3c5c7d0ec739ecc1d54cfc018596f1eca4743",
+                "sha256:6d6647da006469eb3b75c7f5f9bae46e82da2f673c77d73c5ca84204c5ba210e",
+                "sha256:859422978d025befe42da44125e8511b41287994ac5c2d982034f8a9558f356d",
+                "sha256:8f6e333ff0b01f0645fe1469a1883844f3a53a028de4a47b999c423b8de13991",
+                "sha256:9bdd9751d3d3e80b4898fa33ab3d225a4c32ede8e6125121b5f7ac15e63a6eda",
+                "sha256:a879961a2c917a6ab77259b4e93a6cfb9b78a5831d07dd12a660b9abc5da920a",
+                "sha256:bb4334da4ff128fc2a592695d2352ba2286e839eaa55ab39aba77eeee2953635",
+                "sha256:d45ee6c0008149575c53c358bd1832c98752ce31dcc299b4bcfd43a074c3a1a8",
+                "sha256:ee3b3c6462b06b87eefe298dea9b8bff05c77cc25cb8ebd5c5ff2f553971a464"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
+        },
         "e1839a8": {
             "editable": true,
             "path": "."
@@ -44,7 +73,6 @@
                 "sha256:322709555aafc38773961ac3ce7cd606bd513d1389e78dcad73625e13025fb5a",
                 "sha256:f4e344d0cc30c8f3e7c11033d4d6b7f57c2c9a27b263bebce392d58d23efbce4"
             ],
-            "index": "pypi",
             "version": "==0.59"
         },
         "pyjsparser": {

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ PyPAC: Proxy auto-config for Python
 .. image:: https://img.shields.io/codacy/grade/71ac103b491d44efb94976ca5ea5d89c.svg?maxAge=2592000
     :target: https://www.codacy.com/app/carsonyl/pypac
 
-PyPAC is a pure-Python library for finding `proxy auto-config (PAC)`_ files and making HTTP requests
+PyPAC is a Python library for finding `proxy auto-config (PAC)`_ files and making HTTP requests
 that respect them. PAC files are often used in organizations that need fine-grained and centralized control
 of proxy settings.
 

--- a/docs/about_pac.rst
+++ b/docs/about_pac.rst
@@ -102,7 +102,7 @@ How PyPAC works
 
 PyPAC implements PAC file discovery via Windows Internet Options and the DNS portion of the WPAD protocol.
 It implements all of the functions necessary to execute a PAC file,
-and uses the `Js2Py`_ library to parse and execute the JavaScript.
+and uses the `dukpy`_ library to parse and execute the JavaScript.
 On top of this, PyPAC implements tools to track proxy failover state,
 and to convert the return value of the JavaScript function into a form understood by the Requests API.
 
@@ -111,7 +111,7 @@ the proxy configuration for the given URL.
 
 DHCP WPAD is currently not implemented.
 
-.. _Js2Py: https://github.com/PiotrDabkowski/Js2Py
+.. _dukpy: https://pypi.org/p/dukpy
 
 
 Can't I just hard-code the proxy?

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -36,10 +36,6 @@ PAC parsing and execution
 
 .. autoclass:: pypac.parser.MalformedPacError
 
-.. autoclass:: pypac.parser.PyimportError
-
-.. autoclass:: pypac.parser.PacComplexityError
-
 
 PAC JavaScript functions
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Release v\ |version|.
 .. image:: https://img.shields.io/codacy/grade/71ac103b491d44efb94976ca5ea5d89c.svg?maxAge=2592000
     :target: https://www.codacy.com/app/carsonyl/pypac
 
-PyPAC is a pure-Python library for finding :doc:`proxy auto-config (PAC) <about_pac>` files and making HTTP requests
+PyPAC is a Python library for finding :doc:`proxy auto-config (PAC) <about_pac>` files and making HTTP requests
 that respect them. PAC files are often used in organizations that need fine-grained and centralized control
 of proxy settings. :ref:`Are you using one? <who-uses-pacs>`
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -117,16 +117,6 @@ PyPAC defines some exceptions that can occur in the course of PAC auto-discovery
 :class:`MalformedPacError <pypac.parser.MalformedPacError>`
    PyPAC failed to parse a file that claims to be a PAC.
 
-:class:`PyimportError <pypac.parser.PyimportError>`
-   A PAC file contains the ``pyimport`` keyword specific to Js2Py.
-   This represents a serious security issue.
-
-:class:`PacComplexityError <pypac.parser.PacComplexityError>`
-   PAC file is large enough that it couldn't be parsed under the current recursion limit.
-   The recursion limit can be raised using :ref:`sys.setrecursionlimit`,
-   or the ``recursion_limit`` keyword on the :class:`PACSession` constructor.
-   **Note:** It's possible for this exception to not be raised successfully.
-
 :class:`ProxyConfigExhaustedError <pypac.resolver.ProxyConfigExhaustedError>`
    All proxy servers for the given URL have been marked as failed,
    and the PAC file did not specify a final instruction to go ``DIRECT``.
@@ -141,8 +131,8 @@ Supporting and using PAC files comes with some security implications that are wo
 PAC discovery and parsing
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-PAC files are JavaScript. PyPAC uses `Js2Py <https://github.com/PiotrDabkowski/Js2Py>`_
-to parse and execute JavaScript. Js2Py was not designed for handling untrusted JavaScript,
+PAC files are JavaScript. PyPAC uses `dukpy <https://pypi.org/p/dukpy>`_
+to parse and execute JavaScript. dukpy was not designed for handling untrusted JavaScript,
 and so it is unclear whether the handling of PAC files is sufficiently sandboxed to prevent
 untrusted Python code execution.
 

--- a/pypac/parser_functions.py
+++ b/pypac/parser_functions.py
@@ -15,19 +15,6 @@ from requests.utils import is_ipv4_address
 import struct
 
 
-def _to_py(value):
-    """
-    Convert a Js2Py value to an Python primitive.
-
-    :param str|PyJs value: Value to convert.
-    :rtype: str
-    """
-    from js2py.base import PyJs  # Defer to conserve memory when PAC not loaded.
-    if isinstance(value, PyJs):
-        return value.value
-    return value
-
-
 def dnsDomainIs(host, domain):
     """
     :param str|PyJsString host: is the hostname from the URL.
@@ -35,7 +22,6 @@ def dnsDomainIs(host, domain):
     :return: true iff the domain of hostname matches.
     :rtype: bool
     """
-    host, domain = _to_py(host), _to_py(domain)
     if domain.startswith('.'):
         domain = '*' + domain
     return shExpMatch(host, domain)
@@ -49,7 +35,7 @@ def shExpMatch(host, pattern):
     :param str|PyJsString pattern: Shell expression pattern to match against.
     :rtype: bool
     """
-    return fnmatch(_to_py(host).lower(), _to_py(pattern).lower())
+    return fnmatch(host.lower(), pattern.lower())
 
 
 def _address_in_network(ip, netaddr, mask):
@@ -74,7 +60,6 @@ def isInNet(host, pattern, mask):
     :returns: True iff the IP address of the host matches the specified IP address pattern.
     :rtype: bool
     """
-    host, pattern, mask = _to_py(host), _to_py(pattern), _to_py(mask)
     host_ip = host if is_ipv4_address(host) else dnsResolve(host)
     if not host_ip or not is_ipv4_address(pattern) or not is_ipv4_address(mask):
         return False
@@ -89,7 +74,6 @@ def localHostOrDomainIs(host, hostdom):
         or if there is no domain name part in the hostname, but the unqualified hostname matches.
     :rtype: bool
     """
-    host, hostdom = _to_py(host), _to_py(hostdom)
     return hostdom.lower().startswith(host.lower())
 
 
@@ -111,7 +95,7 @@ def dnsResolve(host):
     :rtype: str|None
     """
     try:
-        return socket.gethostbyname(_to_py(host))
+        return socket.gethostbyname(host)
     except socket.gaierror:
         return  # Eat DNS resolution failures.
 
@@ -134,7 +118,7 @@ def isResolvable(host):
     :rtype: bool
     """
     try:
-        socket.gethostbyname(_to_py(host))
+        socket.gethostbyname(host)
     except socket.gaierror:
         return False
     return True
@@ -146,7 +130,7 @@ def dnsDomainLevels(host):
     :return: the number (integer) of DNS domain levels (number of dots) in the hostname.
     :rtype: int
     """
-    return _to_py(host).count('.')
+    return host.count('.')
 
 
 def weekdayRange(start_day, end_day=None, gmt=None):
@@ -172,7 +156,6 @@ def weekdayRange(start_day, end_day=None, gmt=None):
     :param str|PyJsString gmt: is either the string: GMT or is left out.
     :rtype: bool
     """
-    start_day, end_day = _to_py(start_day), _to_py(end_day)
     now_weekday_num = _now('GMT' if end_day == 'GMT' else gmt).weekday()
     weekdays = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
 
@@ -195,7 +178,7 @@ def _now(gmt=None):
     :param str|PyJsString|None gmt: Use 'GMT' to get GMT.
     :rtype: datetime
     """
-    return datetime.utcnow() if _to_py(gmt) == 'GMT' else datetime.today()
+    return datetime.utcnow() if gmt == 'GMT' else datetime.today()
 
 
 def dateRange(*args):
@@ -233,7 +216,6 @@ def dateRange(*args):
 
     :rtype: bool
     """
-    args = list(map(_to_py, args))
     months = [None, 'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
     gmt_arg_present = (len(args) == 2 and args[1] == 'GMT') or (len(args) % 2 == 1 and len(args) > 1)
     if gmt_arg_present:
@@ -308,7 +290,6 @@ def timeRange(*args):
     :return: True during (or between) the specified time(s).
     :rtype: bool
     """
-    args = list(map(_to_py, args))
     gmt_arg_present = (len(args) == 2 and args[1] == 'GMT') or (len(args) % 2 == 1 and len(args) > 1)
     if gmt_arg_present:
         # Remove and handle GMT argument.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'requests >= 2.0.0, < 3.0.0',
     'tld >= 0.7.3, < 1.0.0',
-    'js2py >= 0.43',
+    'dukpy >= 0.2.0, < 1.0.0',
     'pyobjc-framework-SystemConfiguration >= 3.2.1; sys.platform=="darwin"',
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ from requests.utils import select_proxy
 from tempfile import mkstemp
 
 from pypac.api import get_pac, collect_pac_urls, download_pac, PACSession, pac_context_for_url
-from pypac.parser import PACFile, MalformedPacError, ARBITRARY_HIGH_RECURSION_LIMIT
+from pypac.parser import PACFile, MalformedPacError
 from pypac.resolver import proxy_parameter_for_requests
 
 proxy_pac_js_tpl = 'function FindProxyForURL(url, host) { return "%s"; }'
@@ -226,7 +226,7 @@ class TestPACSession(object):
             # When re-enabled, PAC discovery should proceed and be honoured.
             sess.pac_enabled = True
             assert sess.get(arbitrary_url).status_code == 204
-            gp.assert_called_with(recursion_limit=ARBITRARY_HIGH_RECURSION_LIMIT)
+            gp.assert_called_with()
             request.assert_called_with('GET', arbitrary_url, proxies=fake_proxies_requests_arg, allow_redirects=ANY)
 
     @pytest.mark.parametrize('proxy_host', ['unreachable.local', 'localhost'])


### PR DESCRIPTION
This changes PyPAC to use [dukpy](https://github.com/amol-/dukpy) instead of [js2py](https://github.com/PiotrDabkowski/Js2Py) for its JavaScript engine. This simplifies PyPAC's API and should eliminate memory usage concerns. A few months ago, dukpy started distributing wheels for Windows in addition to Mac and Linux, which is great timing.

* Removed `recursion_limit` argument on `pypac.PACSession` and `pypac.parser.PACFile`. Usage now results in a deprecation warning. This behaviour is not configurable in dukpy, and should not be a problem in practice.
* Deprecated `pypac,parser.PyimportError` and `pypac,parser.PacComplexityError`. These no longer get raised. Usage now results in a deprecation warning.
* `pypac.parser.MalformedPacError` conveys the dukpy exception that it masked.

Expected to fix #20 and #22.