### PR TITLE
pac_context_for_url(): Don't set None for proxy env vars.

### DIFF
--- a/pypac/api.py
+++ b/pypac/api.py
@@ -301,8 +301,9 @@ def pac_context_for_url(url, proxy_auth=None):
     if pac:
         resolver = ProxyResolver(pac, proxy_auth=proxy_auth)
         proxies = resolver.get_proxy_for_requests(url)
-        os.environ['HTTP_PROXY'] = proxies.get('http')
-        os.environ['HTTPS_PROXY'] = proxies.get('https')
+        # Cannot set None for environ. (#27)
+        os.environ['HTTP_PROXY'] = proxies.get('http') or ''
+        os.environ['HTTPS_PROXY'] = proxies.get('https') or ''
     yield
     if prev_http_proxy:
         os.environ['HTTP_PROXY'] = prev_http_proxy

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -368,3 +368,11 @@ class TestContextManager(object):
                 assert os.environ['HTTP_PROXY'] == fake_proxy_url
                 assert os.environ['HTTPS_PROXY'] == fake_proxy_url
         assert os.environ['HTTP_PROXY'] == 'http://env'
+
+    def test_pac_direct(self, monkeypatch):
+        monkeypatch.setenv('HTTP_PROXY', 'http://env')
+        with _patch_get_pac(PACFile(proxy_pac_js_tpl % 'DIRECT')):
+            with pac_context_for_url(arbitrary_url):
+                assert os.environ['HTTP_PROXY'] == ''
+                assert os.environ['HTTPS_PROXY'] == ''
+        assert os.environ['HTTP_PROXY'] == 'http://env'


### PR DESCRIPTION
Fixes #27.