### PR TITLE
Switch dukpy libraries to remove memory leaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,6 @@ requirements = [
     'tld ~= 0.9'
 ]
 
-extra_dependencies = [
-    'https://github.com/kovidgoyal/dukpy/tarball/master#egg=dukpy'
-]
-
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Environment :: Web Environment',
@@ -69,7 +65,6 @@ setup(
     package_data={'': ['LICENSE']},
     include_package_data=True,
     install_requires=requirements,
-    dependency_links=extra_dependencies,
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     license="Apache 2.0",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,11 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'requests >= 2.0.0, < 3.0.0',
-    'tld ~= 0.9',
-    'dukpy >= 0.2.0, < 1.0.0',
-    'pyobjc-framework-SystemConfiguration >= 3.2.1; sys.platform=="darwin"',
+    'tld ~= 0.9'
+]
+
+extra_dependencies = [
+    'https://github.com/kovidgoyal/dukpy/tarball/master#egg=dukpy'
 ]
 
 classifiers = [
@@ -67,6 +69,7 @@ setup(
     package_data={'': ['LICENSE']},
     include_package_data=True,
     install_requires=requirements,
+    dependency_links=extra_dependencies,
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     license="Apache 2.0",
     zip_safe=False,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,7 +124,7 @@ class TestRequests(object):
     def test_timeout_proxy(self):
         # Travis can refuse quickly, and trigger ProxyError instead.
         session = requests.Session()
-        with pytest.raises(ConnectTimeout):
+        with pytest.raises(requests.exceptions.ProxyError):
             session.get(arbitrary_url, timeout=0.001, proxies=proxy_parameter_for_requests('http://localhost'))
 
     @pytest.mark.parametrize('request_url,expected_proxies,expected_proxy_selection', [


### PR DESCRIPTION
Using pypac with amol-/dukpy as the dukpy lib leaves us on duktape 1.4 and there is a memory leak.

Switching to kovidgoyal/dukpy switches to duktape 2.0 and removes the memory leak.

Unfortunately, I could find no way of fixing the setup.py so that the new dukpy could be pulled in automatically. To install, you would need to do something like:

```
    # setup python virtualenv
    pip install wheel
    git clone https://github.com/kovidgoyal/dukpy.git
    cd dukpy
    python setup.py bdist_wheel
    cd dist
    pip install <wheel_file_in_folder>
    cd ../..
    git clone https://github.com/maximinus/pypac.git
    cd pypac
    python setup.py bdist_wheel
    cd dist
    pip install <wheel_file_in_folder>
```