### PR TITLE
Fix for issue #34 - dnsResolve() now always returns a string

### DIFF
--- a/pypac/parser_functions.py
+++ b/pypac/parser_functions.py
@@ -89,15 +89,16 @@ def myIpAddress():
 def dnsResolve(host):
     """
     Resolves the given DNS hostname into an IP address, and returns it in the dot separated format as a string.
+    Returns an empty string if there is an error
 
     :param str|PyJsString host: hostname to resolve
-    :return: Resolved IP address, or `None` if resolution failed.
-    :rtype: str|None
+    :return: Resolved IP address, or empty string if resolution failed.
+    :rtype: str
     """
     try:
         return socket.gethostbyname(host)
     except socket.gaierror:
-        return  # Eat DNS resolution failures.
+        return ''
 
 
 def isPlainHostName(host):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -90,6 +90,14 @@ class TestFunctionsInPacParser(object):
         parser = PACFile(js)
         assert parser.find_proxy_for_url('/', 'www.google.com') is not None
 
+    def test_dnsResolve_propagation(self):
+        """
+        dnsResolve must return an empty string now we use dukpy, otherwise
+        None value causes dukpy error as it propagates
+        """
+        parser = PACFile(dummy_js % 'isInNet(dnsResolve(host), "10.1.1.0", "255.255.255.0")')
+        assert parser.find_proxy_for_url('$%$', '$%$') == 'PROXY 0.0.0.0:80'
+
     def test_dnsDomainLevels(self):
         parser = PACFile(dummy_js % 'dnsDomainLevels(host)')
         assert parser.find_proxy_for_url('/', 'google.com') == 'DIRECT'

--- a/tests/test_parser_functions.py
+++ b/tests/test_parser_functions.py
@@ -50,7 +50,7 @@ def test_myIpAddress():
 
 def test_dnsResolve():
     assert dnsResolve('google.com').count('.') == 3
-    assert dnsResolve('bogus.domain.foobar') is None
+    assert dnsResolve('bogus.domain.foobar') == ''
 
 
 @pytest.mark.parametrize('host,expected_levels', [


### PR DESCRIPTION
Stops duktape crashing if another js function depends on the result of dnsResolve being a string.