### PR TITLE
HTTPS proxy and non-PACsession update

### DIFF
--- a/pypac/parser.py
+++ b/pypac/parser.py
@@ -39,7 +39,7 @@ class PACFile(object):
         """
         Load a PAC file from a given string of JavaScript.
         Errors during parsing and validation may raise a specialized exception.
-        
+
         :param str pac_js: JavaScript that defines the FindProxyForURL() function.
         :raises MalformedPacError: If the JavaScript could not be parsed, does not define FindProxyForURL(),
             or is otherwise invalid.
@@ -140,6 +140,8 @@ def proxy_url(value, socks_scheme=None):
 
     if len(parts) == 2:
         keyword, proxy = parts[0].upper(), parts[1]
+        if keyword == 'HTTPS':
+            return 'https://' + proxy
         if keyword == 'PROXY':
             return 'http://' + proxy
         if keyword == 'SOCKS':


### PR DESCRIPTION
Hi,
Pypac does not allow to set session options before pac file reading, session.headers for example. Some services that provide pac file checks User-Agent and provide different responses.
That is why I changed it, to allow this:
```
session = PACSession()
session.headers.update({'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0'})
pac = session.get_pac(url='https://antizapret.prostovpn.org/proxy.pac')
```
Also I added HTTPS value to the valid values in `proxy_url()` 
 