### PR TITLE
Quote username and password in add_proxy_auth

### DIFF
--- a/pypac/resolver.py
+++ b/pypac/resolver.py
@@ -5,7 +5,10 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
-
+try:
+    from urllib import quote_plus
+except ImportError:
+    from urllib.parse import quote_plus
 from pypac.parser import parse_pac_value
 
 
@@ -121,7 +124,12 @@ def add_proxy_auth(possible_proxy_url, proxy_auth):
     if possible_proxy_url == 'DIRECT':
         return possible_proxy_url
     parsed = urlparse(possible_proxy_url)
-    return '{0}://{1}:{2}@{3}'.format(parsed.scheme, proxy_auth.username, proxy_auth.password, parsed.netloc)
+    return '{0}://{1}:{2}@{3}'.format(
+        parsed.scheme,
+        quote_plus(proxy_auth.username),
+        quote_plus(proxy_auth.password),
+        parsed.netloc
+    )
 
 
 def proxy_parameter_for_requests(proxy_url_or_direct):

--- a/pypac/resolver.py
+++ b/pypac/resolver.py
@@ -6,9 +6,10 @@ try:
 except ImportError:
     from urlparse import urlparse
 try:
-    from urllib import quote_plus
-except ImportError:
     from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
+
 from pypac.parser import parse_pac_value
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -43,6 +43,7 @@ def test_proxy_failover_no_fallback():
     ('DIRECT', mock_proxy_auth, 'DIRECT'),
     ('http://foo:8080', mock_proxy_auth, 'http://user:pwd@foo:8080'),
     ('socks5://foo:8080', mock_proxy_auth, 'socks5://user:pwd@foo:8080'),
+    ('http://foo:8080', HTTPProxyAuth('u$er', 'p@ss:'), 'http://u%24er:p%40ss%3A@foo:8080'),
 ])
 def test_add_proxy_auth(proxy_value, auth_obj, expected_result):
     assert add_proxy_auth(proxy_value, auth_obj) == expected_result


### PR DESCRIPTION
Use `urllib.quote_plus` to urlencode the username and password before adding them in the proxy url.