### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ description = Proxy auto-config and auto-discovery for Python.
 long_description = file: README.rst, HISTORY.rst
 keywords = pypac, pac, proxy, autoconfig, requests
 url = https://github.com/carsonyl/pypac
-license = Apache License 2.0
+license = Apache-2.0
 license_file = LICENSE
 classifiers =
     Programming Language :: Python :: 2


### PR DESCRIPTION
Use SPDX license identifier: Apache-2.0
This will help tools to produce valid SPDX.