### PR TITLE
Store the actual PAC script

### DIFF
--- a/pypac/parser.py
+++ b/pypac/parser.py
@@ -64,6 +64,7 @@ class PACFile(object):
 
         except dukpy.JSRuntimeError as e:
             raise MalformedPacError(original_exc=e)  # from e
+        self.js = pac_js
 
     def find_proxy_for_url(self, url, host):
         """


### PR DESCRIPTION
Library users may be just interested in using the library for the ease of obtaining the PAC js, instead of trying to evaluate a proxy in-situ. For example, if the PACScript needs to be serialized to be sent to another process.