### PR TITLE
feat(content-type): add warning if a pac file is found but the content-type is invalid

### DIFF
--- a/pypac/api.py
+++ b/pypac/api.py
@@ -2,6 +2,7 @@
 These are the most commonly used components of PyPAC.
 """
 import os
+import logging
 from contextlib import contextmanager
 
 import requests
@@ -18,6 +19,7 @@ from pypac.os_settings import (
 )
 from pypac.wpad import proxy_urls_from_dns
 
+logger = logging.getLogger(__name__)
 
 def get_pac(
     url=None,
@@ -157,6 +159,9 @@ def download_pac(candidate_urls, timeout=1, allowed_content_types=None, session=
             resp = sess.get(pac_url, timeout=timeout)
             content_type = resp.headers.get("content-type", "").lower()
             if content_type and True not in [allowed_type in content_type for allowed_type in allowed_content_types]:
+                logger.warning(
+                    f"{pac_url} available but content-type {content_type} is not allowed. Only {','.join(allowed_content_types)} are allowed."
+                )
                 continue
             if resp.ok:
                 return resp.text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -78,12 +79,17 @@ class TestApiFunctions(object):
             ({"content-type": "text/plain"}, ["text/plain"], direct_pac_js),
         ],
     )
-    def test_download_pac_content_type(self, headers, allowed_content_types, expected_value):
+    def test_download_pac_content_type(self, headers, allowed_content_types, expected_value, caplog):
         """Test acceptance/rejection of obtained PAC based on Content-Type header."""
         mock_pac_response = Mock(spec=requests.Response, ok=True, headers=headers, text=direct_pac_js)
         with _patch_request_base(mock_pac_response):
             result = download_pac([arbitrary_pac_url], allowed_content_types=allowed_content_types)
             assert result == expected_value
+        if expected_value is None:
+            ex_warn = "available but content-type {} is not allowed".format(headers["content-type"])
+            log = caplog.records[0]
+            assert log.levelno == logging.WARNING
+            assert ex_warn in log.msg
 
     def test_registry_filesystem_path(self):
         """


### PR DESCRIPTION
First thanks for this project. This is really useful to be able to deal with the mess of proxy management.

We are using pypac in one of our project related to QGIS profile deployment : https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli

This was working for one of our client but suddendly there was no more proxy indicated by pypac.

I did some debug and in fact it came from the fact that the content-type of the pac file changed changed. pypac didn't consider the pac file as valid because the content-type is now `text/plain`.

I would like pypac to indicate that a pac file was found but that the content-type is invalid.

I added a warning log.