### PR TITLE
Fix URL encoding mismatch

### DIFF
--- a/pypac/resolver.py
+++ b/pypac/resolver.py
@@ -7,9 +7,9 @@ try:
 except ImportError:
     from urlparse import urlparse  # noqa
 try:
-    from urllib.parse import quote_plus
+    from urllib.parse import quote
 except ImportError:
-    from urllib import quote_plus  # noqa
+    from urllib import quote  # noqa
 
 from pypac.parser import parse_pac_value
 
@@ -128,7 +128,7 @@ def add_proxy_auth(possible_proxy_url, proxy_auth):
         return possible_proxy_url
     parsed = urlparse(possible_proxy_url)
     return "{0}://{1}:{2}@{3}".format(
-        parsed.scheme, quote_plus(proxy_auth.username), quote_plus(proxy_auth.password), parsed.netloc
+        parsed.scheme, quote(proxy_auth.username), quote(proxy_auth.password), parsed.netloc
     )
 
 

--- a/pypac/resolver.py
+++ b/pypac/resolver.py
@@ -128,7 +128,7 @@ def add_proxy_auth(possible_proxy_url, proxy_auth):
         return possible_proxy_url
     parsed = urlparse(possible_proxy_url)
     return "{0}://{1}:{2}@{3}".format(
-        parsed.scheme, quote(proxy_auth.username), quote(proxy_auth.password), parsed.netloc
+        parsed.scheme, quote(proxy_auth.username, safe=""), quote(proxy_auth.password, safe=""), parsed.netloc
     )
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -63,7 +63,7 @@ def test_resolver_add_proxy_auth():
 
 
 def test_requests_proxy_auth():
-    pypac_auth = HTTPProxyAuth('user', 'Pass phr@s3+')
+    pypac_auth = HTTPProxyAuth("user", "Pass phr@s3+/")
     requests_auth = get_auth_from_url(add_proxy_auth(arbitrary_url, pypac_auth))
     assert (pypac_auth.username, pypac_auth.password) == requests_auth
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,6 @@
 import pytest
 from requests.auth import HTTPProxyAuth
+from requests.utils import get_auth_from_url
 
 from pypac.parser import PACFile, proxy_url
 from pypac.resolver import ProxyResolver, add_proxy_auth, ProxyConfigExhaustedError
@@ -59,6 +60,12 @@ def test_add_proxy_auth(proxy_value, auth_obj, expected_result):
 def test_resolver_add_proxy_auth():
     res = _get_resolver("PROXY foo:8080", mock_proxy_auth)
     assert res.get_proxy(arbitrary_url) == "http://user:pwd@foo:8080"
+
+
+def test_requests_proxy_auth():
+    pypac_auth = HTTPProxyAuth('user', 'Pass phr@s3+')
+    requests_auth = get_auth_from_url(add_proxy_auth(arbitrary_url, pypac_auth))
+    assert (pypac_auth.username, pypac_auth.password) == requests_auth
 
 
 def test_get_proxy_for_requests():


### PR DESCRIPTION
Hello @carsonyl , 

Thanks for your work on this project, it has been really helpful in corporate environment.

I opened this PR to fix a bug in proxy authentication URL encoding.

PyPac uses `quote_plus` for encoding whereas requests uses `unquote` for decoding.
https://github.com/carsonyl/pypac/blob/44fd400d04638e1e699835f1819423f17abf0e43/pypac/resolver.py#L130-L132
https://github.com/psf/requests/blob/420d16bc7ef326f7b65f90e4644adc0f6a0e1d44/src/requests/utils.py#L1017.

It leads to space (` `) character not being decoded correctly on requests side, resulting in 407 proxy error.

I would highly appreciate this fix to be merged.

Regards,