### PR TITLE
Correctly detect AutoConfigURL on managed Windows systems

### DIFF
--- a/pypac/os_settings.py
+++ b/pypac/os_settings.py
@@ -48,6 +48,14 @@ def autoconfig_url_from_registry():
         ) as key:
             return winreg.QueryValueEx(key, "AutoConfigURL")[0]
     except WindowsError:
+        pass  # Key or value not found.
+
+    try:
+        with winref.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
+        ) as key:
+            return winreg.QueryValueEx(key, "AutoConfigURL")[0]
+    except WindowsError:
         return  # Key or value not found.
 
 
@@ -108,3 +116,4 @@ class NotWindowsError(Exception):
 class NotDarwinError(Exception):
     def __init__(self):
         super(NotDarwinError, self).__init__("Platform is not macOS/OSX.")
+

--- a/pypac/os_settings.py
+++ b/pypac/os_settings.py
@@ -6,8 +6,9 @@ import platform
 from sys import version_info
 
 if version_info[0] == 2:
-    from urlparse import urlparse  # noqa
-    from urllib import unquote  # noqa
+    from urllib import unquote  # type: ignore
+
+    from urlparse import urlparse  # type: ignore
 else:
     from urllib.parse import urlparse, unquote  # noqa
 
@@ -21,11 +22,11 @@ ON_DARWIN = platform.system() == "Darwin"
 if ON_WINDOWS:
     try:
         import winreg
-    except ImportError:
-        import _winreg as winreg  # PY2.
+    except ImportError:  # PY2.
+        import _winreg as winreg  # type: ignore
 
 if ON_DARWIN:
-    import SystemConfiguration
+    import SystemConfiguration  # type: ignore
 
 
 _INTERNET_SETTINGS_PATH = "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"

--- a/pypac/os_settings.py
+++ b/pypac/os_settings.py
@@ -1,9 +1,9 @@
 """
 Tools for getting the configured PAC file URL out of the OS settings.
 """
+
 import platform
 from sys import version_info
-
 
 if version_info[0] == 2:
     from urlparse import urlparse  # noqa
@@ -28,11 +28,34 @@ if ON_DARWIN:
     import SystemConfiguration
 
 
+_INTERNET_SETTINGS_PATH = "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
+
+
+def _is_per_user_proxy_setting():
+    """
+    Get the PAC ``ProxySettingsPerUser`` value from the Windows Registry.
+
+    See https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-ie-clientnetworkprotocolimplementation-hklmproxyenable.
+
+    :return: True if settings are per-user (default), False if per-machine.
+    :rtype: bool
+    """
+    try:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, _INTERNET_SETTINGS_PATH) as key:
+            value, _ = winreg.QueryValueEx(key, "ProxySettingsPerUser")
+            return value != 0
+    except WindowsError:
+        return True
+
+
 def autoconfig_url_from_registry():
     """
     Get the PAC ``AutoConfigURL`` value from the Windows Registry.
     This setting is visible as the "use automatic configuration script" field in
     Internet Options > Connection > LAN Settings.
+
+    If ``ProxySettingsPerUser`` is 0, only HKLM is checked.
+    If it is non-zero or absent, HKCU is checked first, then HKLM as a fallback.
 
     :return: The value from the registry, or None if the value isn't configured or available.
         Note that it may be local filesystem path instead of a URL.
@@ -42,21 +65,18 @@ def autoconfig_url_from_registry():
     if not ON_WINDOWS:
         raise NotWindowsError()
 
-    try:
-        with winreg.OpenKey(
-            winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
-        ) as key:
-            return winreg.QueryValueEx(key, "AutoConfigURL")[0]
-    except WindowsError:
-        pass  # Key or value not found.
+    hives = [winreg.HKEY_LOCAL_MACHINE]
+    if _is_per_user_proxy_setting():
+        hives.insert(0, winreg.HKEY_CURRENT_USER)  # Check HKCU first in per-user mode.
 
-    try:
-        with winreg.OpenKey(
-            winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
-        ) as key:
-            return winreg.QueryValueEx(key, "AutoConfigURL")[0]
-    except WindowsError:
-        return  # Key or value not found.
+    for hive in hives:
+        try:
+            with winreg.OpenKey(hive, _INTERNET_SETTINGS_PATH) as key:
+                return winreg.QueryValueEx(key, "AutoConfigURL")[0]
+        except WindowsError:
+            pass
+
+    return None
 
 
 def autoconfig_url_from_preferences():
@@ -116,5 +136,3 @@ class NotWindowsError(Exception):
 class NotDarwinError(Exception):
     def __init__(self):
         super(NotDarwinError, self).__init__("Platform is not macOS/OSX.")
-
-

--- a/pypac/os_settings.py
+++ b/pypac/os_settings.py
@@ -51,7 +51,7 @@ def autoconfig_url_from_registry():
         pass  # Key or value not found.
 
     try:
-        with winref.OpenKey(
+        with winreg.OpenKey(
             winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
         ) as key:
             return winreg.QueryValueEx(key, "AutoConfigURL")[0]
@@ -116,4 +116,5 @@ class NotWindowsError(Exception):
 class NotDarwinError(Exception):
     def __init__(self):
         super(NotDarwinError, self).__init__("Platform is not macOS/OSX.")
+
 

--- a/tests/test_os_settings.py
+++ b/tests/test_os_settings.py
@@ -1,5 +1,6 @@
-import pytest
 from subprocess import CalledProcessError
+
+import pytest
 
 try:
     from unittest.mock import patch
@@ -8,13 +9,18 @@ except ImportError:
 
 import sys
 
+try:
+    import winreg
+except ImportError:
+    winreg = None
+
 from pypac.os_settings import (
-    autoconfig_url_from_registry,
-    autoconfig_url_from_preferences,
-    NotWindowsError,
-    NotDarwinError,
-    ON_WINDOWS,
     ON_DARWIN,
+    ON_WINDOWS,
+    NotDarwinError,
+    NotWindowsError,
+    autoconfig_url_from_preferences,
+    autoconfig_url_from_registry,
     file_url_to_local_path,
 )
 
@@ -53,9 +59,56 @@ def _patch_winreg_qve(**kwargs):
 
 
 @pytest.mark.skipif(not_windows, reason=windows_reason)
-def test_mock_autoconfigurl_windows():
-    with _patch_winreg_qve(return_value=(test_reg_output_url, "foo")):
-        assert autoconfig_url_from_registry() == test_reg_output_url
+@pytest.mark.parametrize(
+    "openkey_success, qve_value, expected",
+    [
+        pytest.param(False, None, True, id="absent-key"),
+        pytest.param(True, (1, 4), True, id="per-user"),  # ProxySettingsPerUser=1
+        pytest.param(True, (0, 4), False, id="per-machine"),  # ProxySettingsPerUser=0
+    ],
+)
+def test_is_per_user_proxy_setting(openkey_success, qve_value, expected):
+    """_is_per_user_proxy_setting returns expected bool based on registry state."""
+    with patch("pypac.os_settings.winreg.OpenKey") as mock_openkey:
+        if openkey_success:
+            mock_openkey.return_value.__enter__.return_value = mock_openkey.return_value
+        else:
+            mock_openkey.side_effect = WindowsError()
+        with patch("pypac.os_settings.winreg.QueryValueEx", return_value=qve_value):
+            from pypac.os_settings import _is_per_user_proxy_setting
+
+            assert _is_per_user_proxy_setting() is expected
+
+
+@pytest.mark.skipif(not_windows, reason=windows_reason)
+@pytest.mark.parametrize(
+    "per_user, expected_hive",
+    [
+        pytest.param(True, winreg.HKEY_CURRENT_USER, id="per-user"),
+        pytest.param(False, winreg.HKEY_LOCAL_MACHINE, id="per-machine"),
+    ],
+)
+def test_autoconfig_url_from_registry_mode(per_user, expected_hive):
+    """autoconfig_url_from_registry checks the correct hive in per-user and per-machine mode."""
+    with patch("pypac.os_settings._is_per_user_proxy_setting", return_value=per_user):
+        with patch("pypac.os_settings.winreg.OpenKey") as mock_openkey:
+            mock_openkey.return_value.__enter__.return_value = mock_openkey.return_value
+            with _patch_winreg_qve(return_value=(test_reg_output_url, "foo")):
+                assert autoconfig_url_from_registry() == test_reg_output_url
+            mock_openkey.assert_called_once()
+            assert mock_openkey.call_args[0][0] == expected_hive
+
+
+@pytest.mark.skipif(not_windows, reason=windows_reason)
+def test_per_machine_mode_no_fallback_to_hkcu():
+    """In per-machine mode, when HKLM has no AutoConfigURL, return None without checking HKCU."""
+    with patch("pypac.os_settings._is_per_user_proxy_setting", return_value=False):
+        with patch("pypac.os_settings.winreg.OpenKey") as mock_openkey:
+            mock_openkey.return_value.__enter__.return_value = mock_openkey.return_value
+            with _patch_winreg_qve(side_effect=WindowsError()):
+                assert autoconfig_url_from_registry() is None
+            mock_openkey.assert_called_once()
+            assert mock_openkey.call_args[0][0] == winreg.HKEY_LOCAL_MACHINE
 
 
 def _patch_pyobjc_dscp(**kwargs):
@@ -70,12 +123,14 @@ def test_mock_autoconfigurl_mac():
 
 @pytest.mark.skipif(not_windows, reason=windows_reason)
 def test_reg_errors_reraise_win():
-    with _patch_winreg_qve(side_effect=WindowsError()):
-        assert not autoconfig_url_from_registry()
-    with _patch_winreg_qve(side_effect=CalledProcessError(2, "foo")):
-        with pytest.raises(CalledProcessError) as exinfo:
-            autoconfig_url_from_registry()
-        assert exinfo.value.returncode == 2
+    with patch("pypac.os_settings._is_per_user_proxy_setting", return_value=True):
+        with _patch_winreg_qve(side_effect=WindowsError()):
+            assert not autoconfig_url_from_registry()
+    with patch("pypac.os_settings._is_per_user_proxy_setting", return_value=True):
+        with _patch_winreg_qve(side_effect=CalledProcessError(2, "foo")):
+            with pytest.raises(CalledProcessError) as exinfo:
+                autoconfig_url_from_registry()
+            assert exinfo.value.returncode == 2
 
 
 @pytest.mark.skipif(not_darwin, reason=darwin_reason)

--- a/tests/test_os_settings.py
+++ b/tests/test_os_settings.py
@@ -9,11 +9,6 @@ except ImportError:
 
 import sys
 
-try:
-    import winreg
-except ImportError:
-    winreg = None
-
 from pypac.os_settings import (
     ON_DARWIN,
     ON_WINDOWS,
@@ -23,6 +18,16 @@ from pypac.os_settings import (
     autoconfig_url_from_registry,
     file_url_to_local_path,
 )
+
+HKEY_CURRENT_MACHINE = 0
+HKEY_CURRENT_USER = 1
+if ON_WINDOWS:
+    try:
+        import winreg
+    except ImportError:  # PY2.
+        import _winreg as winreg  # type: ignore
+    HKEY_CURRENT_MACHINE = winreg.HKEY_LOCAL_MACHINE
+    HKEY_CURRENT_USER = winreg.HKEY_CURRENT_USER
 
 test_reg_output_url = "http://foo-bar.baz/x/proxy.pac"
 
@@ -84,8 +89,8 @@ def test_is_per_user_proxy_setting(openkey_success, qve_value, expected):
 @pytest.mark.parametrize(
     "per_user, expected_hive",
     [
-        pytest.param(True, winreg.HKEY_CURRENT_USER, id="per-user"),
-        pytest.param(False, winreg.HKEY_LOCAL_MACHINE, id="per-machine"),
+        pytest.param(True, HKEY_CURRENT_USER, id="per-user"),
+        pytest.param(False, HKEY_CURRENT_MACHINE, id="per-machine"),
     ],
 )
 def test_autoconfig_url_from_registry_mode(per_user, expected_hive):
@@ -108,7 +113,7 @@ def test_per_machine_mode_no_fallback_to_hkcu():
             with _patch_winreg_qve(side_effect=WindowsError()):
                 assert autoconfig_url_from_registry() is None
             mock_openkey.assert_called_once()
-            assert mock_openkey.call_args[0][0] == winreg.HKEY_LOCAL_MACHINE
+            assert mock_openkey.call_args[0][0] == HKEY_CURRENT_MACHINE
 
 
 def _patch_pyobjc_dscp(**kwargs):


### PR DESCRIPTION
On Windows systems managed by an MDM (e.g. InTune), the value of AutoConfigURL might be found under a different key in the registry, namely `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings`. This changeset ensures that the URL is found successfully in such situations.